### PR TITLE
AsMain/makefile: support cross-compiling from x86_64 Mac

### DIFF
--- a/AsMain/makefile
+++ b/AsMain/makefile
@@ -1,5 +1,5 @@
 HelloWorld: HelloWorld.o
-	ld -o HelloWorld HelloWorld.o -lSystem
+	ld -arch arm64 -syslibroot $(shell xcrun -sdk macosx --show-sdk-path) -o HelloWorld HelloWorld.o -lSystem
 
 HelloWorld.o: main.s
-	as -o HelloWorld.o main.s
+	as -arch arm64 -o HelloWorld.o main.s


### PR DESCRIPTION
To support cross-compilation from x86_64:

- explicitly specify arch to be arm64
- Use xcrun to find the SDK path to the active Xcode