### PR TITLE
Do not merge: AsMain: run working HelloWorld asm example for iOS, since I don't have a DTK

### DIFF
--- a/AsMain/main.s
+++ b/AsMain/main.s
@@ -7,6 +7,7 @@
 //
 
 .global _main	            // Provide program starting address to linker
+.p2align 2                  // align _main to 4 byte boundary
 
 // Setup the parameters to print hello world
 // and then call Linux to do it.

--- a/AsMain/makefile
+++ b/AsMain/makefile
@@ -1,5 +1,5 @@
 HelloWorld: HelloWorld.o
-	ld -arch arm64 -syslibroot $(shell xcrun -sdk macosx --show-sdk-path) -o HelloWorld HelloWorld.o -lSystem
+	ld -arch arm64 -platform_version ios 12.0 12.0 -syslibroot $(shell xcrun -sdk macosx --show-sdk-path) -o HelloWorld HelloWorld.o -lSystem
 
 HelloWorld.o: main.s
 	as -arch arm64 -o HelloWorld.o main.s

--- a/AsMain/makefile
+++ b/AsMain/makefile
@@ -1,5 +1,5 @@
 HelloWorld: HelloWorld.o
-	ld -o HelloWorld HelloWorld.o -lSystem
+	ld -arch arm64 -syslibroot $(shell xcrun -sdk macosx --show-sdk-path) -o HelloWorld HelloWorld.o -lSystem
 
 HelloWorld.o: main.s
-	as -o HelloWorld.o main.s
+	as -arch arm64 -o HelloWorld.o main.s


### PR DESCRIPTION
My other PRs should get AsMain working. I don't have a DTK, so I tested these changes by sideloading it to an iPad:

- add these patches
- make
- Create a new Xcode project named HelloWorld
- in Build Phases->Compile Sources, delete everthing
- drag HelloWorld into the project
- Clean build folder, build.
- Make sure the app that's build has the right HelloWorld file.
- Clean build folder, run.

Xcode displays "Hello World!" in the console.

I'm guessing that, since macOS on ARM and iOS are very similar, the alignment change should just work on macOS.