### PR TITLE
Fix alignment in chapter 1 example code

### DIFF
--- a/Chapter 01/HelloWorld.s
+++ b/Chapter 01/HelloWorld.s
@@ -7,7 +7,7 @@
 //
 
 .global _start			// Provide program starting address to linker
-.align 2			// Make sure everything is aligned properly
+.align 4			// Make sure everything is aligned properly
 
 // Setup the parameters to print hello world
 // and then call the Kernel to do it.


### PR DESCRIPTION
Change `.align 2` to `.align 4`.

The README.md tells users to change `.align 2` to `.align 4`, but the change had not been made in this file.