### PR TITLE
System call fix

### DIFF
--- a/Chapter 07/fileio.S
+++ b/Chapter 07/fileio.S
@@ -1,7 +1,7 @@
 // Various macros to perform file I/O
 
 // The fd parameter needs to be a register.
-// Uses X0, X1, X8.
+// Uses X0-X3, X16.
 // Return code is in X0.
 
 #include <sys/syscall.h>

--- a/Chapter 07/fileio.S
+++ b/Chapter 07/fileio.S
@@ -8,7 +8,7 @@
 
 .equ	O_RDONLY, 0
 .equ	O_WRONLY, 1
-.equ	O_CREAT,  0100
+.equ	O_CREAT,  0x00000200
 .equ	S_RDWR,   0666
 .equ	AT_FDCWD, -2
 

--- a/Chapter 07/main.S
+++ b/Chapter 07/main.S
@@ -19,8 +19,8 @@
 
 _start:	MOV		X0, #-1
 	openFile	inFile, O_RDONLY
-	ADDS		X11, XZR, X0	// save file descriptor
-	B.PL		nxtfil  // pos number file opened ok
+	MOV		X11, X0	// save file descriptor (or error)
+	B.CC		nxtfil  // carry clear, file opened ok
 	MOV		X1, #1  // stdout
 	ADRP		X2, inpErrsz@PAGE	// Error msg
 	ADD		X2, X2, inpErrsz@PAGEOFF	
@@ -29,8 +29,8 @@ _start:	MOV		X0, #-1
 	B		exit
 
 nxtfil: openFile	outFile, O_CREAT+O_WRONLY
-	ADDS		X9, XZR, X0	// save file descriptor
-	B.PL		loop    // pos number file opened ok
+	MOV		X9 , X0	// save file descriptor (or error)
+	B.CC		loop    // carry clear, file opened ok
 	MOV		X1, #1
 	ADRP		X2, outErrsz@PAGE
 	ADD		X2, X2, outErrsz@PAGEOFF

--- a/Chapter 07/main.S
+++ b/Chapter 07/main.S
@@ -2,7 +2,7 @@
 // Assembler program to convert a string to
 // all upper case by calling a function.
 //
-// X0-X2, X8 - used by macros to call linux
+// X0-X2, X16 - used by macros to call kernel
 // X11 - input file descriptor
 // X9 - output file descriptor
 // X10 - number of characters read

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ As we learned in Chapter 5, all assembler directives (like `.equ`) must be in lo
 
 It is also important to notice that while the calls and definitions look similar, Linux and Darwin are not the same: `AT_FDCWD` is -100 on Linux, but must be -2 on Darwin.
 
+Unlike Linux, errors are signified by setting the carry flag, and the error codes are non-negative. We therefore `MOV` the result into the required register instead of `ADDS` (we don't need to check for negative numbers, and need to preserve the condition flags) and B.CC to the success path.
+
 ## Chapter 8
 
 This chapter is specifically for the Raspberry Pi 4, so there is nothing to do here.


### PR DESCRIPTION
First off, thank you for creating this repo. It's been a huge help for me.

Anyway I noticed that the chapter 7 code was printing the output to stderr instead of writing to a new file. This was due to two issues:

1. The value for O_CREAT was incorrect. I have copied the correct value from fcntl.h. Without this the openat system call would fail with ENOENT (i.e. 2)
2. On error, the system call returns a positive value and sets the carry flag. As the code in the book doesn't check that, it would assume the call succeeded and use 2 (i.e. stderr) as the output file.

I believe I have fixed these two issues and updated the comments.