### PR TITLE
Remove tracking redirect link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An introduction to assembly on Apple Silicon Macs.
 
 ## Introduction
 
-In this repository, I will code along with the book [Programming with 64-Bit ARM Assembly Language](https://www.dpbolvw.net/click-100586055-13091548?url=https%3A%2F%2Flink.springer.com%2Fbook%2F10.1007%2F978-1-4842-5881-1), adjusting all sample code for Apple's ARM64 line of computers. While Apple's marketing material seems to avoid a name for the platform and talks only about the M1 processor, the developer documentation uses the term "Apple Silicon". I will use this term in the following.
+In this repository, I will code along with the book [Programming with 64-Bit ARM Assembly Language](https://link.springer.com/book/10.1007/978-1-4842-5881-1), adjusting all sample code for Apple's ARM64 line of computers. While Apple's marketing material seems to avoid a name for the platform and talks only about the M1 processor, the developer documentation uses the term "Apple Silicon". I will use this term in the following.
 
 The original sourcecode can be found [here](https://github.com/Apress/programming-with-64-bit-ARM-assembly-language).
 


### PR DESCRIPTION
Replaced with the actual page it redirects to.

(uBlock Origin blocks the tracking page from loading, as it should. Glancing at the history, it seems like this might be a way of collecting affiliate revenue - that's fine, whatever, just add your affiliate tag onto the real URL instead of using an obfuscated URL hosted on a spam server.)