### PR TITLE
Fix typo referecing R0 instead of X0 register

### DIFF
--- a/Chapter 02/addexamp2.s
+++ b/Chapter 02/addexamp2.s
@@ -17,7 +17,7 @@ _start:	MOV	X2, #0x0000000000000003
 
 // Setup the parameters to exit the programc
 // and then call the kernel to do it.
-// R0 is the return code and will be what we
+// X0 is the return code and will be what we
 // calculated above.
 	MOV     X16, #1		// System call number 1 terminates this program
 	SVC     #0x80		// Call kernel to terminate the program


### PR DESCRIPTION
Thanks for this great project, it is very helpful while trying to learn assembly on an Apple machine. I noticed one of your examples was referencing R0 register by mistake instead of X0 register.