### PR TITLE
Avoid using nonstandard assembly syntax for NEON

### DIFF
--- a/Chapter 13/matrixmultneon.s
+++ b/Chapter 13/matrixmultneon.s
@@ -34,9 +34,9 @@ main:
 	LDR	D5, [X0]
 
 .macro mulcol ccol bcol
-	MUL.4H	\ccol\(), V0, \bcol\()[0]
-	MLA.4H	\ccol\(), V1, \bcol\()[1]
-	MLA.4H	\ccol\(), V2, \bcol\()[2]
+	MUL	\ccol\().4H, V0.4H, \bcol\().H[0]
+	MLA	\ccol\().4H, V1.4H, \bcol\().H[1]
+	MLA	\ccol\().4H, V2.4H, \bcol\().H[2]
 .endm
 
 	mulcol	V6, V3	// process first column

--- a/README.md
+++ b/README.md
@@ -335,17 +335,11 @@ Like in Chapter 11, all the chages have been introduced already. Nothing new her
 
 ## Chapter 13: Neon Coprocessor
 
-Once again, the Clang assembler wants a slightly different syntax: Where gcc accepts
-
-```
-MUL V6.4H, V0.4H, V3.4H[0]
-```
-
-the Clang assembler expects
-
-```
-MUL.4H V6, V0, V3[0]
-```
+The example used a nonstandard syntax for referencing a single vector element,
+which GNU assembler accepts, but Clang doesn't.
+Where the example used `V3.4H[0]` for referencing the first 16 bit element,
+the correct, standard syntax is `V3.H[0]`, which is accepted both by GNU
+assembler and Clang.
 
 All other changes to the code should be trivial at this point.
 


### PR DESCRIPTION
While the original form of the example can't be assembled with Clang, the suggested replacement isn't ideal either.

The original form of the example used a nonstandard way of referencing vector elements, by writing `V3.4H[0]`, while the standard form is to drop the total number of elements, writing only `V3.H[0]` - this is supported by both GNU assembler and Clang.

The earlier replacement syntax, with instructions like `MUL.4H`, where the vector layout is specified as part of the instruction instead of as part of the register, is entirely nonstandard. (It is similar to how NEON instructions were written for AArch32 though.) This syntax is accepted by Clang, and is produced by LLVM tools when disassembling Mach-O file, but should not be recommended in new written code.

Thus revert these instructions back to their original form and only apply the element specifier syntax fix, changing `V3.4H[0]` into `V3.H[0]`.