### PR TITLE
refactor: remove unnecessary function declaration

### DIFF
--- a/Chapter 09/uppertst4.c
+++ b/Chapter 09/uppertst4.c
@@ -5,8 +5,6 @@
 
 #include <stdio.h>
 
-extern int mytoupper( char *, char * );
-
 #define MAX_BUFFSIZE 255
 int main()
 {


### PR DESCRIPTION
For the example `uppertst4`, we don't need the function declaration of `mytoupper` because the function isn't used at all.
