### PR TITLE
fix: fix frame pointer manipulation

### DIFF
--- a/Chapter 06/codesnippets.s
+++ b/Chapter 06/codesnippets.s
@@ -49,14 +49,16 @@ l5:	STR	W0, [SP]	// Store a
 
 l6:	ADD	SP, SP, #16
 
-l7:	SUB	FP, SP, #16
+l7:	STR	FP, [SP, #-16]!	// Save FP
+	SUB	FP, SP, #16
 	SUB	SP, SP, #16
 
 l8:	STR	W0, [FP]		// Store a
-	STR	W1, [FP, #-4]	// Store b
-	STR	W2, [FP, #-8]	// Store c
+	STR	W1, [FP, #4]	// Store b
+	STR	W2, [FP, #8]	// Store c
 
 	ADD	SP, SP, #16
+	LDR	FP, [SP], #16	// Restore FP
 
 l9:	BL	SUMFN
 	B	l10


### PR DESCRIPTION
Two changes were made:

1. In the original code, frame pointer `FP` is changed to point to `SP` but doesn't be restored to original value in the end. So, we should save existing `FP` value and restore the value later.
2. The `FP` points to top of stack frame. So the `FP` should refer a variable inside the frame with non-negative offset.
