### PR TITLE
fix: debug format string

### DIFF
--- a/Chapter 09/debug.s
+++ b/Chapter 09/debug.s
@@ -14,10 +14,9 @@
 	stp	    X14, X15, [SP, #-16]!	
 	stp	    X16, X17, [SP, #-16]!	
 	stp	    X18, LR, [SP, #-16]!	
+	mov	    X1, #\reg	// for the %u
 	mov	    X2, X\reg	// for the %d
 	mov	    X3, X\reg	// for the %x
-	mov	    X1, #\reg	
-	add	    X1, X1, #'0'	// for %c
     str     X1, [SP, #-32]! // Move the stack pointer four doublewords (32 bytes) down and push X1 onto the stack
     str     X2, [SP, #8]    // Push X2 to one doubleword above the current stack pointer
     str     X3, [SP, #16]   // Push X3 to two doublewords above the current stack pointer
@@ -67,6 +66,6 @@
 .endm
 
 .data
-ptfStr: .asciz	"X%c = %32ld, 0x%016lx\n"
+ptfStr: .asciz	"X%-2u = %32ld, 0x%016lx\n"
 .align 4
 .text

--- a/Chapter 11/debug.s
+++ b/Chapter 11/debug.s
@@ -14,7 +14,7 @@
 	stp	    X14, X15, [SP, #-16]!	
 	stp	    X16, X17, [SP, #-16]!	
 	stp	    X18, LR, [SP, #-16]!	
-	mov	    X1, #\reg	// for the %c
+	mov	    X1, #\reg	// for the %u
 	mov	    X2, X\reg	// for the %d
 	mov	    X3, X\reg	// for the %x
     str     X1, [SP, #-32]! // Move the stack pointer four doublewords (32 bytes) down and push X1 onto the stack

--- a/Chapter 11/debug.s
+++ b/Chapter 11/debug.s
@@ -14,10 +14,9 @@
 	stp	    X14, X15, [SP, #-16]!	
 	stp	    X16, X17, [SP, #-16]!	
 	stp	    X18, LR, [SP, #-16]!	
+	mov	    X1, #\reg	// for the %c
 	mov	    X2, X\reg	// for the %d
 	mov	    X3, X\reg	// for the %x
-	mov	    X1, #\reg	
-	add	    X1, X1, #'0'	// for %c
     str     X1, [SP, #-32]! // Move the stack pointer four doublewords (32 bytes) down and push X1 onto the stack
     str     X2, [SP, #8]    // Push X2 to one doubleword above the current stack pointer
     str     X3, [SP, #16]   // Push X3 to two doublewords above the current stack pointer
@@ -67,6 +66,6 @@
 .endm
 
 .data
-ptfStr: .asciz	"X%c = %32ld, 0x%016lx\n"
+ptfStr: .asciz	"X%-2u = %32ld, 0x%016lx\n"
 .align 4
 .text


### PR DESCRIPTION
The current format string's conversion specifier `%c` and `x1` with `'0'` added to it do not properly handle cases where the `reg` is `x10` through `x30` — register name is two-digit number. i.e. there is an incorrect assumption that only `x0` through `x9` will be passed.

This fix takes the `reg` passed to `x1` as an integer and processes it with the conversion specifier `%u`; We align the field to left with `-2`.

As a side effect, only `x0` needs to be moved later when calling `printf`, and it doesn't matter which one is moved first: `x1`, `x2`, or `x3`.