### PR TITLE
fix: fpcomp example

### DIFF
--- a/Chapter 12/fpcomp.s
+++ b/Chapter 12/fpcomp.s
@@ -21,7 +21,7 @@ fpcomp:	// load the 3 numbers
 	FSUB	S3, S1, S0
 	FABS	S3, S3
 	FCMP	S3, S2	
-	B.LE		notequal
+	B.GE		notequal
 	MOV		X0, #1
 	B		done	
 	

--- a/Chapter 12/maincomp.s
+++ b/Chapter 12/maincomp.s
@@ -31,6 +31,11 @@ loop:
 	SUBS	W19, W19, #1	// decrement loop counter
 	B.NE	loop		// loop if more points
 
+// Store running sum for later use
+	ADRP	X0, runsum@PAGE
+	ADD	X0, X0, runsum@PAGEOFF
+	STR	S1, [X0]
+
 	// compare running sum to real sum
 	FCMP	S1, S2	
 	// print if the numbers are equal or not


### PR DESCRIPTION
Two fixes were made:

- The `fpcomp` function should return `1` if the arguments are equal(The difference between them is smaller than epsilon), else returns `0`.
- In the `maincomp.s`, before calling `fpcomp`, the previously calculated running sum must be stored into `runsum`.