### PR TITLE
fix: Update clean target to remove codesnippets

### DIFF
--- a/Chapter 02/makefile
+++ b/Chapter 02/makefile
@@ -29,4 +29,4 @@ codesnippets: $(CSOBJS)
 	ld -o codesnippets $(LDFLAGS) $(CSOBJS)
 
 clean:
-	rm *.o movexamps addexamp1 addexamp2
+	rm *.o movexamps addexamp1 addexamp2 codesnippets


### PR DESCRIPTION
This pull request makes a minor update to the `makefile` in `Chapter 02` to improve the cleanup process.

* The `clean` target now also removes the `codesnippets` binary, ensuring all build artifacts are cleaned up.