### PR TITLE
Chapter 11 - Makefile: remove redundant .o rule and -lSystem, add clean target

### DIFF
--- a/Chapter 11/makefile
+++ b/Chapter 11/makefile
@@ -6,12 +6,9 @@ DEBUGFLGS =
 endif
 LSTFLGS =
 
-LDFLAGS = -lSystem -lc -e main -arch arm64
+LDFLAGS = -lc -e main -arch arm64
 
 all: divexamp mulexamp matrixmult
-
-%.o : %.s
-	as $(DEBUGFLGS) $(LSTFLGS) $< -o $@
 
 divexamp: divexamp.s debug.s
 	clang $(LDFLAGS) -o divexamp divexamp.s
@@ -22,4 +19,5 @@ mulexamp: mulexamp.s debug.s
 matrixmult: matrixmult.s
 	clang $(LDFLAGS) -g -o matrixmult matrixmult.s
 
-
+clean: 
+	rm -rf divexamp matrixmult mulexamp


### PR DESCRIPTION
In this change, I have updated the Makefile by removing the unused .o target rule since there is no need to build or reuse object files.

And I have also removed the -lSystem linker flag because Clang automatically links the System library on arm64 macOS, which prevents unnecessary warnings during linking. 

<img width="1258" height="276" alt="946edf613c79b067d7835c84f5f95cbd" src="https://github.com/user-attachments/assets/aa3b677b-87ab-42f7-864e-198e8334c1d2" />

Additionally, I have added a clean target to remove all generated executable files.

And thank you for creating this convenient and helpful repository for learning :)